### PR TITLE
Spotify側の検索機能と曲追加機能

### DIFF
--- a/src/main/java/service/SpotifyAddTrackServlet.java
+++ b/src/main/java/service/SpotifyAddTrackServlet.java
@@ -1,0 +1,144 @@
+package service;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.io.OutputStream;
+import java.net.HttpURLConnection;
+import java.net.URL;
+import java.nio.charset.StandardCharsets;
+
+import javax.servlet.ServletException;
+import javax.servlet.annotation.WebServlet;
+import javax.servlet.http.HttpServlet;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import javax.servlet.http.HttpSession;
+
+import org.json.JSONObject;
+
+@WebServlet("/SpotifyAddTrackServlet")
+public class SpotifyAddTrackServlet extends HttpServlet {
+    private static final long serialVersionUID = 1L;
+    private static final String SPOTIFY_API_URL = "https://api.spotify.com/v1/playlists";
+
+    protected void doPost(HttpServletRequest request, HttpServletResponse response) throws ServletException, IOException {
+        HttpSession session = request.getSession();
+        String accessToken = (String) session.getAttribute("access_token");
+
+        if (accessToken == null) {
+            System.out.println("ERROR: アクセストークンが null です。ログインしてください。");
+            response.getWriter().write("<script>parent.alert('Spotify にログインしてください。');</script>");
+            return;
+        }
+
+        String playlistId = request.getParameter("playlistId");
+        String trackId = request.getParameter("trackId");
+
+        System.out.println("DEBUG: 受け取ったプレイリストID = " + playlistId);
+        System.out.println("DEBUG: 受け取ったトラックID = " + trackId);
+
+        if (playlistId == null || trackId == null || playlistId.isEmpty() || trackId.isEmpty()) {
+            System.out.println("ERROR: プレイリストID または トラックID が不足しています。");
+            response.getWriter().write("<script>parent.alert('プレイリストIDまたはトラックIDが不足しています。');</script>");
+            return;
+        }
+        
+        // ?? プレイリストのオーナーを確認
+        String playlistOwner = getPlaylistOwner(playlistId, accessToken);
+        String currentUserId = getCurrentUserId(accessToken);
+
+        System.out.println("DEBUG: プレイリストのオーナーID = " + playlistOwner);
+        System.out.println("DEBUG: 現在のユーザーID = " + currentUserId);
+
+        if (!playlistOwner.equals(currentUserId)) {
+            System.out.println("ERROR: このプレイリストは現在のユーザーが作成したものではありません。");
+            response.getWriter().write("<script>parent.alert('このプレイリストには曲を追加できません (オーナー権限なし)。');</script>");
+            return;
+        }
+
+        boolean success = addTrackToPlaylist(playlistId, trackId, accessToken);
+
+        System.out.println("DEBUG: APIリクエスト完了 - 成功: " + success);
+
+        // ?? 結果を JavaScript で親ページに通知
+        response.setContentType("text/html; charset=UTF-8");
+        response.getWriter().write("<script>parent.alert('" + (success ? "追加成功！" : "追加に失敗しました。") + "');</script>");
+    }
+
+    private boolean addTrackToPlaylist(String playlistId, String trackId, String accessToken) throws IOException {
+        String urlString = SPOTIFY_API_URL + "/" + playlistId + "/tracks";
+        URL url = new URL(urlString);
+        HttpURLConnection connection = (HttpURLConnection) url.openConnection();
+
+        connection.setRequestMethod("POST");
+        connection.setRequestProperty("Authorization", "Bearer " + accessToken);
+        connection.setRequestProperty("Content-Type", "application/json");
+        connection.setDoOutput(true);
+
+        String jsonBody = "{\"uris\": [\"spotify:track:" + trackId + "\"]}";
+
+        System.out.println("DEBUG: 送信URL = " + urlString);
+        System.out.println("DEBUG: 送信JSON = " + jsonBody);
+
+        try (OutputStream os = connection.getOutputStream()) {
+            byte[] input = jsonBody.getBytes(StandardCharsets.UTF_8);
+            os.write(input, 0, input.length);
+        }
+
+        int responseCode = connection.getResponseCode();
+        System.out.println("DEBUG: APIレスポンスコード = " + responseCode);
+
+        if (responseCode != 201) {
+            System.out.println("ERROR: APIリクエスト失敗 - HTTP " + responseCode);
+            return false;
+        }
+
+        return true;
+    }
+
+    private String sendSpotifyRequest(String urlString, String accessToken) throws IOException {
+        System.out.println("DEBUG: Spotify API リクエスト - " + urlString);
+
+        URL url = new URL(urlString);
+        HttpURLConnection connection = (HttpURLConnection) url.openConnection();
+        connection.setRequestMethod("GET");
+        connection.setRequestProperty("Authorization", "Bearer " + accessToken);
+        connection.setRequestProperty("Content-Type", "application/json");
+
+        int responseCode = connection.getResponseCode();
+        System.out.println("DEBUG: Spotify API Response Code - " + responseCode);
+
+        if (responseCode != 200) {
+            throw new IOException("Spotify API Error: HTTP " + responseCode);
+        }
+
+        BufferedReader in = new BufferedReader(new InputStreamReader(connection.getInputStream(), StandardCharsets.UTF_8));
+        StringBuilder response = new StringBuilder();
+        String inputLine;
+        while ((inputLine = in.readLine()) != null) {
+            response.append(inputLine);
+        }
+        in.close();
+
+        System.out.println("DEBUG: Spotify API Response Body - " + response.toString());
+
+        return response.toString();
+    }
+
+    // ?? プレイリストのオーナーを取得
+    private String getPlaylistOwner(String playlistId, String accessToken) throws IOException {
+        String urlString = "https://api.spotify.com/v1/playlists/" + playlistId;
+        String response = sendSpotifyRequest(urlString, accessToken);
+        JSONObject json = new JSONObject(response);
+        return json.getJSONObject("owner").getString("id");
+    }
+
+    // ?? 現在のユーザーの ID を取得
+    private String getCurrentUserId(String accessToken) throws IOException {
+        String urlString = "https://api.spotify.com/v1/me";
+        String response = sendSpotifyRequest(urlString, accessToken);
+        JSONObject json = new JSONObject(response);
+        return json.getString("id");
+    }
+}

--- a/src/main/java/service/SpotifyAuthServlet.java
+++ b/src/main/java/service/SpotifyAuthServlet.java
@@ -30,7 +30,7 @@ public class SpotifyAuthServlet extends HttpServlet {
                     + "?client_id=" + SpotifyAuthService.CLIENT_ID
                     + "&response_type=code"
                     + "&redirect_uri=" + java.net.URLEncoder.encode(SpotifyAuthService.REDIRECT_URI, "UTF-8")
-                    + "&scope=streaming user-read-playback-state user-modify-playback-state playlist-read-private playlist-read-collaborative user-follow-read user-read-private user-read-email user-top-read user-read-recently-played";
+                    + "&scope=streaming user-read-playback-state user-modify-playback-state playlist-read-private playlist-read-collaborative user-follow-read user-read-private user-read-email user-top-read user-read-recently-played playlist-modify-private playlist-modify-public";
             response.sendRedirect(authUrl);
             return;
         }

--- a/src/main/java/service/SpotifySearchServlet.java
+++ b/src/main/java/service/SpotifySearchServlet.java
@@ -1,0 +1,391 @@
+package service;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.net.HttpURLConnection;
+import java.net.URL;
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import javax.servlet.ServletException;
+import javax.servlet.annotation.WebServlet;
+import javax.servlet.http.HttpServlet;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import javax.servlet.http.HttpSession;
+
+import org.json.JSONArray;
+import org.json.JSONObject;
+
+
+@WebServlet("/SpotifySearchServlet")
+public class SpotifySearchServlet extends HttpServlet {
+    private static final long serialVersionUID = 1L;
+    private static final String SPOTIFY_API_URL = "https://api.spotify.com/v1/search";
+
+    protected void doGet(HttpServletRequest request, HttpServletResponse response) throws ServletException, IOException {
+        String action = request.getParameter("action");
+        String id = request.getParameter("id");
+        String query = request.getParameter("query");
+
+        System.out.println("DEBUG: action=" + action + ", id=" + id + ", query=" + query);
+
+        HttpSession session = request.getSession();
+        String accessToken = (String) session.getAttribute("access_token");
+
+        if (accessToken == null) {
+            request.setAttribute("error", "Spotifyにログインしていません。");
+            request.getRequestDispatcher("/WEB-INF/jsp/search.jsp").forward(request, response);
+            return;
+        }
+
+        try {
+            if (query != null && !query.trim().isEmpty()) {
+                // ?? Spotify検索を実行
+                System.out.println("DEBUG: Spotify検索を実行します - " + query);
+                String jsonResponse = searchSpotify(query, accessToken);
+                System.out.println("DEBUG: Spotify API Response - " + jsonResponse);
+
+                JSONObject json = new JSONObject(jsonResponse);
+
+                // ?? 各検索結果のデータを取得
+                JSONArray artistsArray = json.optJSONObject("artists").optJSONArray("items");
+                JSONArray albumsArray = json.optJSONObject("albums").optJSONArray("items");
+                JSONArray playlistsArray = json.optJSONObject("playlists").optJSONArray("items");
+                JSONArray tracksArray = json.optJSONObject("tracks").optJSONArray("items"); // ?? 曲のデータを取得
+
+                System.out.println("DEBUG: artistsArray = " + artistsArray);
+                System.out.println("DEBUG: albumsArray = " + albumsArray);
+                System.out.println("DEBUG: playlistsArray = " + playlistsArray);
+                System.out.println("DEBUG: tracksArray = " + tracksArray);
+
+                // ?? JSON → List に変換
+                List<Map<String, Object>> artistList = JsonToListConverter.convertJSONArrayToList(artistsArray);
+                List<Map<String, Object>> albumList = JsonToListConverter.convertJSONArrayToList(albumsArray);
+                List<Map<String, Object>> playlistList = JsonToListConverter.convertJSONArrayToList(playlistsArray);
+                List<Map<String, Object>> trackList = JsonToListConverter.convertJSONArrayToList(tracksArray); // ?? 曲リストに変換
+
+                System.out.println("DEBUG: 結果データ (tracks) - " + trackList);
+
+
+             // ?? trackList に画像URLをセットする
+             for (Map<String, Object> track : trackList) {
+                 JSONObject album = (JSONObject) track.get("album"); // アルバム情報を取得
+                 JSONArray imagesArray = (album != null) ? album.optJSONArray("images") : null;
+
+                 String imageUrl = "no_image.png"; // デフォルト画像
+                 if (imagesArray != null && imagesArray.length() > 0) {
+                     JSONObject firstImage = imagesArray.optJSONObject(0);
+                     if (firstImage != null) {
+                         imageUrl = firstImage.optString("url", "no_image.png");
+                     }
+                 }
+
+                 track.put("image", imageUrl); // ?? 画像URLをセット
+             }
+
+             // ?? デバッグログで確認
+             System.out.println("DEBUG: 修正後の trackList:");
+             for (Map<String, Object> track : trackList) {
+                 System.out.println("Track: " + track.get("name") + ", Image: " + track.get("image"));
+             }
+                // ?? JSP にデータを渡す
+                request.setAttribute("artists", artistList);
+                request.setAttribute("albums", albumList);
+                request.setAttribute("playlists", playlistList);
+                request.setAttribute("tracks", trackList);
+                request.setAttribute("query", query);
+
+                // ?? ユーザーのプレイリストを取得
+                String userPlaylistsUrl = "https://api.spotify.com/v1/me/playlists";
+                JSONObject playlistResponse = new JSONObject(sendSpotifyRequest(userPlaylistsUrl, accessToken));
+                JSONArray userPlaylistsArray = playlistResponse.optJSONArray("items");
+                List<Map<String, Object>> userPlaylists = JsonToListConverter.convertJSONArrayToList(userPlaylistsArray);
+                request.setAttribute("userPlaylists", userPlaylists);
+
+                // ?? 検索結果をJSPに渡す
+                request.getRequestDispatcher("/WEB-INF/jsp/search.jsp").forward(request, response);
+            } 
+            else if ("playlist".equals(action)) {
+                System.out.println("DEBUG: プレイリスト詳細取得 - ID: " + id);
+                JSONObject playlist = getSpotifyDetails("playlists", id, accessToken);
+                System.out.println("DEBUG: プレイリスト情報 - " + playlist.toString());
+
+                // プレイリスト情報を変換
+                Map<String, Object> playlistInfo = convertPlaylistDetails(playlist);
+
+                // トラック情報を変換
+                JSONArray tracksArray = playlist.optJSONObject("tracks").optJSONArray("items");
+                List<Map<String, Object>> trackList = convertPlaylistTracks(tracksArray);
+
+                // ?? 変換されたデータをリクエストにセット
+                request.setAttribute("playlist", playlistInfo);
+                request.setAttribute("tracks", trackList);
+
+                request.getRequestDispatcher("/WEB-INF/jsp/searchplaylist.jsp").forward(request, response);
+            } 
+            else if ("artist".equals(action)) {
+                // アーティスト詳細を取得
+                System.out.println("DEBUG: アーティスト詳細取得 - ID: " + id);
+                JSONObject artistJson = getSpotifyDetails("artists", id, accessToken);
+                System.out.println("DEBUG: アーティスト情報 - " + artistJson.toString());
+
+                // JSONObject を Map に変換
+                Map<String, Object> artist = convertArtistDetails(artistJson);
+
+                // 人気曲の取得
+                String topTracksUrl = "https://api.spotify.com/v1/artists/" + id + "/top-tracks?market=JP";
+                JSONObject topTracksResponse = new JSONObject(sendSpotifyRequest(topTracksUrl, accessToken));
+                JSONArray topTracksArray = topTracksResponse.optJSONArray("tracks");
+
+                // アルバム一覧の取得
+                String albumsUrl = "https://api.spotify.com/v1/artists/" + id + "/albums?include_groups=album&market=JP&limit=10";
+                JSONObject albumsResponse = new JSONObject(sendSpotifyRequest(albumsUrl, accessToken));
+                JSONArray albumsArray = albumsResponse.optJSONArray("items");
+
+                // JSON を List<Map<String, Object>> に変換
+                List<Map<String, Object>> topTracks = JsonToListConverter.convertJSONArrayToList(topTracksArray);
+                List<Map<String, Object>> albums = JsonToListConverter.convertJSONArrayToList(albumsArray);
+
+                // JSP にデータを渡す
+                request.setAttribute("artist", artist);
+                request.setAttribute("top_tracks", topTracks);
+                request.setAttribute("albums", albums);
+
+                request.getRequestDispatcher("/WEB-INF/jsp/searchartist.jsp").forward(request, response);
+            } 
+            else if ("album".equals(action)) {
+                // アルバム詳細を取得
+                System.out.println("DEBUG: アルバム詳細取得 - ID: " + id);
+                JSONObject albumJson = getSpotifyDetails("albums", id, accessToken);
+                System.out.println("DEBUG: アルバム情報 - " + albumJson.toString());
+
+                // JSONObject を Map に変換
+                Map<String, Object> album = convertAlbumDetails(albumJson);
+
+                // 収録曲の取得
+                JSONArray tracksArray = albumJson.optJSONObject("tracks").optJSONArray("items");
+                List<Map<String, Object>> tracks = JsonToListConverter.convertJSONArrayToList(tracksArray);
+
+                // JSP にデータを渡す
+                request.setAttribute("album", album);
+                request.setAttribute("tracks", tracks);
+
+                request.getRequestDispatcher("/WEB-INF/jsp/searchalbum.jsp").forward(request, response);
+            } 
+            else {
+                request.getRequestDispatcher("/WEB-INF/jsp/search.jsp").forward(request, response);
+            }
+        } catch (Exception e) {
+            System.out.println("ERROR: 例外が発生しました - " + e.getMessage());
+            e.printStackTrace();
+            request.setAttribute("error", "エラーが発生しました: " + e.getMessage());
+            request.getRequestDispatcher("/WEB-INF/jsp/search.jsp").forward(request, response);
+        }
+    }
+
+
+    // ?? Spotify検索API
+    private String searchSpotify(String query, String accessToken) throws IOException {
+        String encodedQuery = URLEncoder.encode(query, StandardCharsets.UTF_8.toString());
+        String urlString = SPOTIFY_API_URL + "?q=" + encodedQuery + "&type=track,album,artist,playlist&limit=10";
+        return sendSpotifyRequest(urlString, accessToken);
+    }
+
+    // Spotify詳細取得API
+    private JSONObject getSpotifyDetails(String type, String id, String accessToken) throws IOException {
+        String urlString = "https://api.spotify.com/v1/" + type + "/" + id;
+        String response = sendSpotifyRequest(urlString, accessToken);
+        return new JSONObject(response);
+    }
+
+    // ?? Spotify API リクエスト送信
+    private String sendSpotifyRequest(String urlString, String accessToken) throws IOException {
+        System.out.println("DEBUG: Spotify API リクエスト - " + urlString);
+
+        URL url = new URL(urlString);
+        HttpURLConnection connection = (HttpURLConnection) url.openConnection();
+        connection.setRequestMethod("GET");
+        connection.setRequestProperty("Authorization", "Bearer " + accessToken);
+        connection.setRequestProperty("Content-Type", "application/json");
+
+        int responseCode = connection.getResponseCode();
+        System.out.println("DEBUG: Spotify API Response Code - " + responseCode);
+
+        if (responseCode != 200) {
+            throw new IOException("Spotify API Error: HTTP " + responseCode);
+        }
+
+        BufferedReader in = new BufferedReader(new InputStreamReader(connection.getInputStream(), StandardCharsets.UTF_8));
+        StringBuilder response = new StringBuilder();
+        String inputLine;
+        while ((inputLine = in.readLine()) != null) {
+            response.append(inputLine);
+        }
+        in.close();
+
+        System.out.println("DEBUG: Spotify API Response Body - " + response.toString());
+
+        return response.toString();
+    }
+
+
+    public static class JsonToListConverter {
+        public static List<Map<String, Object>> convertJSONArrayToList(JSONArray jsonArray) {
+            List<Map<String, Object>> list = new ArrayList<>();
+            if (jsonArray == null) return list; // nullチェック
+
+            for (int i = 0; i < jsonArray.length(); i++) {
+                Object element = jsonArray.get(i);
+                if (!(element instanceof JSONObject)) {
+                    System.out.println("WARNING: Skipping non-JSONObject element at index " + i + ": " + element);
+                    continue; // JSONObject でない場合はスキップ
+                }
+
+                JSONObject jsonObject = (JSONObject) element;
+                Map<String, Object> map = new HashMap<>();
+
+                for (String key : jsonObject.keySet()) {
+                    Object value = jsonObject.get(key);
+
+                    // images フィールドの場合は List<Map<String, Object>> に変換
+                    if ("images".equals(key) && value instanceof JSONArray) {
+                        map.put(key, convertJSONArrayToList((JSONArray) value));
+                    } else {
+                        map.put(key, value);
+                    }
+                }
+
+                list.add(map);
+            }
+            return list;
+        }
+    }
+
+    // プレイリストの詳細情報を変換するメソッド
+    public static Map<String, Object> convertPlaylistDetails(JSONObject playlist) {
+        Map<String, Object> playlistInfo = new HashMap<>();
+        if (playlist == null) return playlistInfo;
+
+        playlistInfo.put("name", playlist.optString("name", "不明なプレイリスト"));
+        playlistInfo.put("owner", playlist.optJSONObject("owner") != null ? playlist.optJSONObject("owner").optString("display_name", "不明な作成者") : "不明な作成者");
+
+        // images の処理
+        JSONArray imagesArray = playlist.optJSONArray("images");
+        List<Map<String, Object>> imagesList = new ArrayList<>();
+        if (imagesArray != null) {
+            for (int i = 0; i < imagesArray.length(); i++) {
+                JSONObject imageObject = imagesArray.optJSONObject(i);
+                if (imageObject != null) {
+                    Map<String, Object> imageMap = new HashMap<>();
+                    imageMap.put("url", imageObject.optString("url", "no_image.png"));
+                    imagesList.add(imageMap);
+                }
+            }
+        }
+        playlistInfo.put("images", imagesList);
+
+        return playlistInfo;
+    }
+
+    // プレイリストのトラック情報を変換するメソッド
+ // プレイリストのトラック情報を変換するメソッド
+    public static List<Map<String, Object>> convertPlaylistTracks(JSONArray tracksArray) {
+        List<Map<String, Object>> trackList = new ArrayList<>();
+        if (tracksArray == null) return trackList; // nullチェック
+
+        for (int i = 0; i < tracksArray.length(); i++) {
+            JSONObject trackObject = tracksArray.optJSONObject(i);
+            if (trackObject == null || !trackObject.has("track")) continue;
+
+            JSONObject track = trackObject.getJSONObject("track");
+            Map<String, Object> trackInfo = new HashMap<>();
+            trackInfo.put("name", track.optString("name", "不明なトラック"));
+            trackInfo.put("track_number", track.optInt("track_number", 0));
+            trackInfo.put("id", track.optString("id", "unknown_id"));
+
+            // 🔹 **アルバム画像の取得**
+            JSONObject album = track.optJSONObject("album");
+            JSONArray imagesArray = (album != null) ? album.optJSONArray("images") : null;
+
+            String imageUrl = "no_image.png"; // デフォルト画像
+            if (imagesArray != null && imagesArray.length() > 0) {
+                imageUrl = imagesArray.getJSONObject(0).optString("url", "no_image.png");
+            }
+
+            // 🔹 **デバッグログ追加**
+            System.out.println("DEBUG: Track - Name: " + track.optString("name", "Unknown") + 
+                               ", Album: " + (album != null ? album.optString("name", "Unknown Album") : "No Album") + 
+                               ", Image: " + imageUrl);
+
+            trackInfo.put("image", imageUrl);
+            trackList.add(trackInfo);
+        }
+        return trackList;
+    }
+
+ // アーティスト情報を Map に変換
+    private static Map<String, Object> convertArtistDetails(JSONObject artistJson) {
+        Map<String, Object> artist = new HashMap<>();
+        
+        artist.put("id", artistJson.optString("id", ""));
+        artist.put("name", artistJson.optString("name", "不明なアーティスト"));
+        artist.put("followers", artistJson.optJSONObject("followers") != null 
+            ? artistJson.optJSONObject("followers").optInt("total", 0) 
+            : 0);
+
+        // images の処理
+        JSONArray imagesArray = artistJson.optJSONArray("images");
+        List<Map<String, Object>> imagesList = new ArrayList<>();
+        if (imagesArray != null) {
+            for (int i = 0; i < imagesArray.length(); i++) {
+                JSONObject imageObject = imagesArray.optJSONObject(i);
+                if (imageObject != null) {
+                    Map<String, Object> imageMap = new HashMap<>();
+                    imageMap.put("url", imageObject.optString("url", "no_image.png"));
+                    imagesList.add(imageMap);
+                }
+            }
+        }
+        artist.put("images", imagesList);
+
+        return artist;
+    }
+    
+ // アルバム情報を Map に変換
+    private static Map<String, Object> convertAlbumDetails(JSONObject albumJson) {
+        Map<String, Object> album = new HashMap<>();
+        
+        album.put("id", albumJson.optString("id", ""));
+        album.put("name", albumJson.optString("name", "不明なアルバム"));
+        album.put("release_date", albumJson.optString("release_date", "不明な日付"));
+
+        // images の処理
+        JSONArray imagesArray = albumJson.optJSONArray("images");
+        List<Map<String, Object>> imagesList = new ArrayList<>();
+        if (imagesArray != null) {
+            for (int i = 0; i < imagesArray.length(); i++) {
+                JSONObject imageObject = imagesArray.optJSONObject(i);
+                if (imageObject != null) {
+                    Map<String, Object> imageMap = new HashMap<>();
+                    imageMap.put("url", imageObject.optString("url", "no_image.png"));
+                    imagesList.add(imageMap);
+                }
+            }
+        }
+        album.put("images", imagesList);
+
+        return album;
+    }
+
+
+}
+
+
+
+

--- a/src/main/webapp/WEB-INF/jsp/main.jsp
+++ b/src/main/webapp/WEB-INF/jsp/main.jsp
@@ -141,6 +141,14 @@
             <img src="<c:url value='/img/Spotmusic.webp' />" alt="ロゴを配置" class="reload-icon">
         </a>
     </div>
+    
+    <!--  検索ボックス -->
+    <form action="SpotifySearchServlet" method="get">
+    	<input type="text" name="query" placeholder="何を再生したいですか？" required>
+    	<button class="search-button" type="submit">検索</button>
+	</form>
+    <!-- ここまで　　　　　  -->
+    
     <div class="actions">
         <!-- アカウントアイコン -->
         <div class="account-container">

--- a/src/main/webapp/WEB-INF/jsp/search.jsp
+++ b/src/main/webapp/WEB-INF/jsp/search.jsp
@@ -1,0 +1,121 @@
+<%@ taglib uri="http://java.sun.com/jsp/jstl/core" prefix="c" %>
+<%@ page contentType="text/html; charset=UTF-8" pageEncoding="UTF-8" %>
+<!DOCTYPE html>
+<html>
+<head>
+    <title>検索結果</title>
+    <link rel="stylesheet" type="text/css" href="<c:url value='/css/styles.css' />">
+</head>
+<body>
+
+    <h1>検索結果</h1>
+
+	<h3>曲</h3>
+	<c:if test="${not empty tracks}">
+	    <ul class="track-list">
+	        <c:forEach var="track" items="${tracks}">
+	            <li class="track-item">
+				<c:choose>
+				    <c:when test="${not empty track.image}">
+				        <img src="${track.image}" alt="アルバム画像" width="50">
+				    </c:when>
+				    <c:otherwise>
+				        <img src="no_image.png" alt="No Image" width="50">
+				    </c:otherwise>
+				</c:choose>
+
+	                ${track.track_number}. ${track.name}
+	
+	                <!-- ?? Java で処理するフォーム -->
+	                <form action="SpotifyAddTrackServlet" method="post" target="hidden_iframe">
+	                    <input type="hidden" name="trackId" value="${track.id}">
+	                    <select name="playlistId">
+	                        <c:forEach var="playlist" items="${userPlaylists}">
+	                            <option value="${playlist.id}">${playlist.name}</option>
+	                        </c:forEach>
+	                    </select>
+	                    <button type="submit">追加</button>
+	                </form>
+	            </li>
+	        </c:forEach>
+	    </ul>
+	</c:if>
+	
+	<!-- ?? 隠し iframe (リクエスト処理用) -->
+	<iframe name="hidden_iframe" style="display: none;"></iframe>
+	
+
+
+
+    <!-- ?? ユーザーのプレイリストを選択するモーダル -->
+    <div id="playlistModal" style="display: none;">
+        <h3>プレイリストを選択</h3>
+        <select id="playlistSelect">
+            <c:forEach var="playlist" items="${userPlaylists}">
+                <option value="${playlist.id}">${playlist.name}</option>
+            </c:forEach>
+        </select>
+        <button id="confirmAddButton">追加</button>
+    </div>
+
+    <h2>アーティスト</h2>
+    <c:if test="${not empty artists}">
+        <ul>
+            <c:forEach var="artist" items="${artists}">
+                <li>
+                    <a href="SpotifySearchServlet?action=artist&id=${artist['id']}">
+                        <img src="${not empty artist['images'] ? artist['images'][0]['url'] : 'no_image.png'}" 
+                             alt="${artist['name']}" width="100">
+                    </a>
+                    ${artist['name']}
+                </li>
+            </c:forEach>
+        </ul>
+    </c:if>
+    <c:if test="${empty artists}">
+        <p>アーティストが見つかりませんでした。</p>
+    </c:if>
+
+    <h2>アルバム</h2>
+    <c:if test="${not empty albums}">
+        <ul>
+            <c:forEach var="album" items="${albums}">
+                <li>
+                    <a href="SpotifySearchServlet?action=album&id=${album['id']}">
+                        <img src="${not empty album['images'] ? album['images'][0]['url'] : 'no_image.png'}" width="100">
+                        ${album['name']}
+                    </a>
+                </li>
+            </c:forEach>
+        </ul>
+    </c:if>
+    <c:if test="${empty albums}">
+        <p>アルバムが見つかりませんでした。</p>
+    </c:if>
+    
+    <h2>プレイリスト</h2>
+    <c:if test="${not empty playlists}">
+        <ul>
+            <c:forEach var="playlist" items="${playlists}">
+                <li>
+                    <a href="SpotifySearchServlet?action=playlist&id=${playlist['id']}">
+                        <img src="${not empty playlist['images'] ? playlist['images'][0]['url'] : 'no_image.png'}" width="100">
+                        ${playlist['name']}
+                    </a>
+                </li>
+            </c:forEach>
+        </ul>
+    </c:if>
+    <c:if test="${empty playlists}">
+        <p>プレイリストが見つかりませんでした。</p>
+    </c:if>
+
+    <a href="javascript:history.back()" class="back-button">戻る</a>
+    
+        <!-- メッセージ表示 -->
+    <c:if test="${not empty message}">
+        <p>${message}</p>
+    </c:if>
+
+</body>
+</html>

--- a/src/main/webapp/WEB-INF/jsp/searchalbum.jsp
+++ b/src/main/webapp/WEB-INF/jsp/searchalbum.jsp
@@ -1,0 +1,42 @@
+<%@ taglib uri="http://java.sun.com/jsp/jstl/core" prefix="c" %>
+<%@ page contentType="text/html; charset=UTF-8" pageEncoding="UTF-8" %>
+<!DOCTYPE html>
+<html>
+<head>
+    <title>アルバム詳細</title>
+    <link rel="stylesheet" type="text/css" href="<c:url value='/css/styles.css' />">
+</head>
+<body>
+    <h1>アルバム詳細</h1>
+
+    <c:if test="${not empty album}">
+        <div>
+            <!-- アルバム画像 -->
+			<c:if test="${not empty album.images}">
+			    <img src="${album.images[0].url}" width="200">
+			</c:if>
+
+            <c:if test="${empty album['images']}">
+                <img src="no_image.png" alt="No Image" width="200">
+            </c:if>
+
+            <h2>${album['name']}</h2>
+            <p>リリース日: ${album['release_date']}</p>
+        </div>
+
+	<h3>収録曲</h3>
+	<ul>
+	    <c:forEach var="track" items="${tracks}">
+	        <li>${track['track_number']}. ${track['name']}</li>
+	    </c:forEach>
+	</ul>
+
+    </c:if>
+
+    <c:if test="${empty album}">
+        <p>アルバムが見つかりませんでした。</p>
+    </c:if>
+
+    <a href="javascript:history.back()" class="back-button">戻る</a>
+</body>
+</html>

--- a/src/main/webapp/WEB-INF/jsp/searchartist.jsp
+++ b/src/main/webapp/WEB-INF/jsp/searchartist.jsp
@@ -1,0 +1,64 @@
+<%@ taglib uri="http://java.sun.com/jsp/jstl/core" prefix="c" %>
+<%@ page contentType="text/html; charset=UTF-8" pageEncoding="UTF-8" %>
+<!DOCTYPE html>
+<html>
+<head>
+    <title>アーティスト詳細</title>
+    <link rel="stylesheet" type="text/css" href="<c:url value='/css/styles.css' />">
+</head>
+<body>
+    <h1>アーティスト詳細</h1>
+
+    <c:if test="${not empty artist}">
+        <div>
+            <!-- アーティスト画像 -->
+			<c:if test="${not empty artist.images}">
+			    <img src="${artist.images[0].url}" alt="アーティスト画像" width="200">
+			</c:if>
+
+            <c:if test="${empty artist['images']}">
+                <img src="no_image.png" alt="No Image" width="200">
+            </c:if>
+
+            <h2>${artist['name']}</h2>
+            <!-- フォロワー数の表示 -->
+            <p>フォロワー: ${artist['followers']}</p>
+        </div>
+
+        <!-- 人気曲 -->
+		 <h3>人気曲</h3>
+		<c:if test="${not empty top_tracks}">
+		    <ul>
+		        <c:forEach var="track" items="${top_tracks}">
+		            <li>${track['name']}</li>
+		        </c:forEach>
+		    </ul>
+		</c:if>
+		<c:if test="${empty top_tracks}">
+		    <p>人気曲が見つかりませんでした。</p>
+		</c:if>
+		
+		<h3>アルバム一覧</h3>
+		<c:if test="${not empty albums}">
+		    <ul>
+		        <c:forEach var="album" items="${albums}">
+		            <li>
+		                <a href="SpotifySearchServlet?action=album&id=${album['id']}">${album['name']}</a>
+		            </li>
+		        </c:forEach>
+		    </ul>
+		</c:if>
+		<c:if test="${empty albums}">
+		    <p>アルバムが見つかりませんでした。</p>
+		</c:if>
+
+
+    </c:if>
+
+    <c:if test="${empty artist}">
+        <p>アーティストが見つかりませんでした。</p>
+    </c:if>
+
+    <a href="javascript:history.back()" class="back-button">戻る</a>
+</body>
+</html>

--- a/src/main/webapp/WEB-INF/jsp/searchplaylist.jsp
+++ b/src/main/webapp/WEB-INF/jsp/searchplaylist.jsp
@@ -1,0 +1,55 @@
+<%@ taglib uri="http://java.sun.com/jsp/jstl/core" prefix="c" %>
+<%@ page contentType="text/html; charset=UTF-8" pageEncoding="UTF-8" %>
+<!DOCTYPE html>
+<html>
+<head>
+    <title>プレイリスト詳細</title>
+    <link rel="stylesheet" type="text/css" href="<c:url value='/css/styles.css' />">
+</head>
+<body>
+    <h1>プレイリスト詳細</h1>
+
+    <div>
+        <!-- プレイリスト画像 -->
+        <c:if test="${not empty playlist['images']}">
+            <img src="${playlist['images'][0]['url']}" alt="プレイリスト画像" width="200">
+        </c:if>
+        <c:if test="${empty playlist['images']}">
+            <img src="no_image.png" alt="No Image" width="200">
+        </c:if>
+
+        <h2>${playlist.name}</h2>
+
+        <!-- 作成者情報の表示 -->
+        <c:if test="${not empty playlist['owner']}">
+            <p>作成者: ${playlist['owner']}</p>
+        </c:if>
+        <c:if test="${empty playlist['owner']}">
+            <p>作成者情報はありません。</p>
+        </c:if>
+    </div>
+
+	<h3>収録曲</h3>
+	<c:if test="${not empty tracks}">
+	    <ul>
+	        <c:forEach var="track" items="${tracks}">
+	            <li>
+	                <c:if test="${not empty track['image']}">
+	                    <img src="${track['image']}" alt="アルバム画像" width="50">
+	                </c:if>
+	                <c:if test="${empty track['image']}">
+	                    <img src="no_image.png" alt="No Image" width="50">
+	                </c:if>
+	                ${track['track_number']}. ${track['name']}
+	            </li>
+	        </c:forEach>
+	    </ul>
+	</c:if>
+	<c:if test="${empty tracks}">
+	    <p>収録曲が見つかりませんでした。</p>
+	</c:if>
+
+
+    <a href="javascript:history.back()" class="back-button">戻る</a>
+</body>
+</html>

--- a/src/main/webapp/css/player.css
+++ b/src/main/webapp/css/player.css
@@ -330,6 +330,10 @@ button {
     border-radius: 4px;
 }
 
+  .search-button {
+      color: black;
+  }
+
 /* コントロールボタンのサイズを大きく */
 #repeat-track,
 #prev,

--- a/src/main/webapp/css/styles.css
+++ b/src/main/webapp/css/styles.css
@@ -1,0 +1,158 @@
+/* 共通設定 */
+body {
+    font-family: Arial, sans-serif;
+    background-color: #121212; /* Spotify のようなダークモード */
+    color: #ffffff;
+    margin: 0;
+    padding: 0;
+    text-align: center;
+}
+
+/* ヘッダー */
+h1 {
+    font-size: 28px;
+    color: #1DB954; /* Spotify のグリーン */
+    margin-top: 20px;
+}
+
+/* セクションのタイトル */
+h2 {
+    border-bottom: 2px solid #1DB954;
+    padding-bottom: 5px;
+    display: inline-block;
+    margin-top: 20px;
+}
+
+/* リストのスタイル */
+ul {
+    list-style-type: none;
+    padding: 0;
+}
+
+li {
+    background-color: #181818;
+    padding: 15px;
+    margin: 10px auto;
+    border-radius: 10px;
+    width: 80%;
+    max-width: 500px;
+    transition: 0.3s;
+}
+
+li:hover {
+    background-color: #282828;
+}
+
+/* リンクスタイル */
+a {
+    text-decoration: none;
+    color: #1DB954;
+    font-weight: bold;
+}
+
+a:hover {
+    text-decoration: underline;
+}
+
+/* 画像のスタイル */
+img {
+    border-radius: 10px;
+    margin-bottom: 10px;
+}
+
+/* ボタン */
+button, .button {
+    background-color: #1DB954;
+    border: none;
+    padding: 10px 15px;
+    color: white;
+    font-size: 16px;
+    border-radius: 5px;
+    cursor: pointer;
+    transition: 0.3s;
+}
+
+button:hover, .button:hover {
+    background-color: #1ed760;
+}
+
+/* プレイリスト詳細ページの調整 */
+div {
+    padding: 20px;
+}
+
+p {
+    margin: 5px 0;
+}
+
+/* レスポンシブデザイン */
+@media (max-width: 600px) {
+    li {
+        width: 95%;
+    }
+}
+
+/* 曲リストのデザイン */
+.track-list {
+    list-style-type: none;
+    padding: 0;
+}
+
+.track-item {
+    background-color: #181818;
+    padding: 10px;
+    margin: 5px 0;
+    border-radius: 8px;
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+}
+
+/* 追加ボタンのスタイル */
+.add-to-playlist-btn {
+    background-color: #1DB954;
+    border: none;
+    padding: 8px 12px;
+    color: white;
+    font-size: 14px;
+    border-radius: 5px;
+    cursor: pointer;
+}
+
+.add-to-playlist-btn:hover {
+    background-color: #1ed760;
+}
+
+/* モーダルのスタイル */
+#playlistModal {
+    display: none;
+    position: fixed;
+    top: 50%;
+    left: 50%;
+    transform: translate(-50%, -50%);
+    background-color: #282828;
+    padding: 20px;
+    border-radius: 10px;
+    width: 300px;
+    text-align: center;
+}
+
+#playlistModal select {
+    width: 100%;
+    padding: 5px;
+    margin-bottom: 10px;
+}
+
+#playlistModal button {
+    background-color: #1DB954;
+    padding: 8px 12px;
+    border: none;
+    color: white;
+    cursor: pointer;
+    border-radius: 5px;
+}
+
+#playlistModal button:hover {
+    background-color: #1ed760;
+}
+


### PR DESCRIPTION
検索ボックス(main.jsp)
→検索結果(search.jsp):曲/アーティスト/アルバム/プレイリスト
→各データの詳細:アーティスト(searchartist.jsp)/アルバム(searchalbum.jsp)/プレイリスト(searchplaylist.jsp)

一時的な検索データの為Beanは一切使用せず、返ってくるjsonデータをString型に変換してそのままJSPで出力しています。

現在search.jspの曲一覧でのみユーザーが任意のプレイリストに曲の追加が出来ます。

フレンド検索等、独自機能関連の検索機能を設ける場合は、独自機能のロジックが分かる人検索ボックスにタブを設ける等何らかの方法で実装お願いします。

