### PR TITLE
Spotifyで検索の左にあるホームボタン追加

### DIFF
--- a/src/main/java/command/GoToMainCommand.java
+++ b/src/main/java/command/GoToMainCommand.java
@@ -1,0 +1,12 @@
+package command;
+
+import context.ResponseContext;
+
+public class GoToMainCommand extends AbstractCommand {
+
+    @Override
+    public ResponseContext execute(ResponseContext responseContext) {
+        responseContext.setTarget("main"); // main.jsp に遷移
+        return responseContext;
+    }
+}

--- a/src/main/resources/command.properties
+++ b/src/main/resources/command.properties
@@ -36,3 +36,4 @@ SpotifyDeletePlaylistCommand=command.SpotifyDeletePlaylistCommand
 SpotifySearchCommand=command.SpotifySearchCommand
 followArtist = command.SpotifyFollowArtistCommand
 addTrack = command.SpotifyAddTrackCommand
+GoToMainCommand=command.GoToMainCommand

--- a/src/main/webapp/WEB-INF/jsp/main.jsp
+++ b/src/main/webapp/WEB-INF/jsp/main.jsp
@@ -46,19 +46,21 @@
 </head>
 <body>
 	<div class="header">
-<<<<<<< HEAD
 	<div class="logo">
 	    <!-- リロード用アイコン -->
 	    <a href="javascript:void(0)" onclick="reloadFollowedArtists()" class="reload-link">
 	        <img src="<c:url value='/img/Spotmusic.webp' />" alt="ロゴを配置" class="reload-icon">
 	    </a>
 	</div>
-    
-<form onsubmit="event.preventDefault(); loadSearchPage();">
-    <input type="text" id="searchQuery" name="query" placeholder="何を再生したいですか？" required>
-    <button class="search-button" type="submit">検索</button>
-</form>
-    <!-- ここまで　　　　　  -->
+    	<!--  ホームに戻る(main.jsp)呼び出し -->
+		<a href="javascript:void(0);" onclick="loadHome()">🏠</a>
+		<!-- ここまで -->
+		<!--  検索  -->
+		<form onsubmit="event.preventDefault(); loadSearchPage();">
+    		<input type="text" id="searchQuery" name="query" placeholder="何を再生したいですか？" required>
+    		<button class="search-button" type="submit">検索</button>
+		</form>
+    	<!-- ここまで -->
     
     <div class="actions">
         <!-- アカウントアイコン -->
@@ -1641,7 +1643,37 @@ function reloadFollowedArtists() {
 
         
     </script>
+<script>
+//ホームに戻る
+    function loadHome() {
+        const url = '/SpotMusic/FrontServlet?command=GoToMainCommand';
+        const contentDiv = document.querySelector('.content'); // メインの表示エリアのみ更新
 
+        fetch(url)
+            .then(response => {
+                if (!response.ok) {
+                    throw new Error('サーバーエラー: ' + response.status);
+                }
+                return response.text();
+            })
+            .then(data => {
+                const tempDiv = document.createElement('div'); // 一時的にレスポンスを挿入
+                tempDiv.innerHTML = data;
+
+                // `.content` の中身だけを更新
+                const newContent = tempDiv.querySelector('.content');
+                if (newContent) {
+                    contentDiv.innerHTML = newContent.innerHTML; // **headerには影響を与えず、.contentだけ更新**
+                }
+
+                console.log("ホームページの .content 部分がロードされました！");
+            })
+            .catch(error => {
+                console.error('エラー発生:', error);
+                contentDiv.innerHTML = '<p>ホーム画面の読み込みに失敗しました。</p>';
+            });
+    }
+</script>
 
 
 

--- a/src/main/webapp/WEB-INF/jsp/playList.jsp
+++ b/src/main/webapp/WEB-INF/jsp/playList.jsp
@@ -113,8 +113,7 @@
 </c:if>
 
 
-    <br>
-    <a href="main.jsp">戻る</a>
+    
 <script>
 $(document).ready(function(){
     $("#commentForm").submit(function(event){

--- a/src/main/webapp/WEB-INF/jsp/search.jsp
+++ b/src/main/webapp/WEB-INF/jsp/search.jsp
@@ -228,7 +228,7 @@
 </div>
 
 
-    <a href="javascript:history.back()" class="back-button">戻る</a>
+    
     
         <!-- メッセージ表示 -->
     <c:if test="${not empty message}">

--- a/src/main/webapp/WEB-INF/jsp/searchalbum.jsp
+++ b/src/main/webapp/WEB-INF/jsp/searchalbum.jsp
@@ -66,6 +66,6 @@
     <p>アルバムが見つかりませんでした。</p>
 </c:if>
 
-<a href="javascript:history.back()" class="back-button">戻る</a>
+
 </body>
 </html>

--- a/src/main/webapp/WEB-INF/jsp/searchartist.jsp
+++ b/src/main/webapp/WEB-INF/jsp/searchartist.jsp
@@ -93,7 +93,7 @@
         <p>アーティストが見つかりませんでした。</p>
     </c:if>
 
-    <a href="javascript:history.back()" class="back-button">戻る</a>
+
 <script>
 //フォロー　フォロー解除ボタン
 document.addEventListener("DOMContentLoaded", function () {

--- a/src/main/webapp/WEB-INF/jsp/searchplaylist.jsp
+++ b/src/main/webapp/WEB-INF/jsp/searchplaylist.jsp
@@ -67,6 +67,5 @@
         <p>収録曲が見つかりませんでした。</p>
     </c:if>
 
-    <a href="javascript:history.back()" class="back-button">戻る</a>
 </body>
 </html>


### PR DESCRIPTION
検索したりプレイリストクリックした後でも画面遷移無しでログイン時のmain.jspの真ん中の部分に戻るだけ
リロードじゃないから曲再生したまま移動できる
デザインは無視してます