### PR TITLE
aws用(確認後までマージ不要)

### DIFF
--- a/src/main/java/connector/MySQLConnector.java
+++ b/src/main/java/connector/MySQLConnector.java
@@ -14,14 +14,21 @@ public class MySQLConnector {
             e.printStackTrace();
         }
     }
+
     public static Connection getConn() {
         Connection conn = null;
-        try{
-            // 接続URLに文字エンコーディングの設定を追加
+        try {
             conn = DriverManager.getConnection(
-                "jdbc:mysql://localhost:3306/spotmusic?useSSL=false&serverTimezone=Asia/Tokyo&useUnicode=true&characterEncoding=UTF-8", 
-                "info", "pro");
-        }catch(SQLException e){
+                    "jdbc:mysql://localhost:3306/spotmusic?useSSL=false&serverTimezone=Asia/Tokyo&useUnicode=true&characterEncoding=UTF-8", 
+                    "info", "pro");
+            // AWS RDSのエンドポイント（画像から取得）　下記はAWS用
+            //String url = "jdbc:mysql://aws-mysql.cfvaqwoyhysi.us-east-1.rds.amazonaws.com:3306/admin"
+                       //+ "?useSSL=false&serverTimezone=Asia/Tokyo&useUnicode=true&characterEncoding=UTF-8";
+            //String user = "";  // RDSのユーザー名　使う時入れる
+            //String password = ""; // RDSのパスワード 使う時入れる
+
+            //conn = DriverManager.getConnection(url, user, password);
+        } catch (SQLException e) {
             e.printStackTrace();
         }
         return conn;

--- a/src/main/java/dao/CommentDAO.java
+++ b/src/main/java/dao/CommentDAO.java
@@ -14,7 +14,7 @@ import connector.MySQLConnector;
 public class CommentDAO {
 	
 	public void addComment(CommentBean commentBean) {
-		String sql = "INSERT INTO COMMENT (PLAYLIST_ID, USER_ID, USER_NAME, SEND_COMMENT, SEND_TIME) VALUES (?,?,?,?,?)";
+		String sql = "insert into comment (playlist_id, user_id, user_name, send_comment, send_time) values (?,?,?,?,?)";
 		try (Connection conn = MySQLConnector.getConn();
 			PreparedStatement stmt = conn.prepareStatement(sql)) {
 			
@@ -36,19 +36,19 @@ public class CommentDAO {
 	
 	public List<CommentBean> getComment(String playlistId) {
         List<CommentBean> comments = new ArrayList<>();
-        String sql = "SELECT * FROM COMMENT WHERE PLAYLIST_ID = ? ORDER BY SEND_TIME DESC";
+        String sql = "select * from comment where playlist_id = ? order by send_time desc";
         try (Connection conn = MySQLConnector.getConn();
              PreparedStatement stmt = conn.prepareStatement(sql)) {
             stmt.setString(1, playlistId);
             ResultSet rs = stmt.executeQuery();
             while (rs.next()) {
             	CommentBean commentBean = new CommentBean(
-                        rs.getInt("COMMENT_ID"),
-                        rs.getString("PLAYLIST_ID"),
-                        rs.getString("USER_ID"),
-                        rs.getString("USER_NAME"),
-                        rs.getTimestamp("SEND_TIME"),
-                        rs.getString("SEND_COMMENT")
+                        rs.getInt("comment_id"),
+                        rs.getString("playlist_id"),
+                        rs.getString("user_id"),
+                        rs.getString("user_name"),
+                        rs.getTimestamp("send_time"),
+                        rs.getString("send_comment")
                 );
                 comments.add(commentBean);  // メッセージをリストに追加
             }
@@ -59,7 +59,7 @@ public class CommentDAO {
     }
 	
 	public void updateComment(CommentBean commentBean) {
-		String sql = "UPDATE COMMENT SET SEND_COMMENT = ? WHERE COMMENT_ID = ?";
+		String sql = "UPDATE comment SET send_comment = ? WHERE comment_id = ?";
 		try (Connection conn = MySQLConnector.getConn();
 			 PreparedStatement stmt = conn.prepareStatement(sql)) {
 			stmt.setString(1, commentBean.getSendComment());
@@ -71,7 +71,7 @@ public class CommentDAO {
 	}
 	
 	public void removeComment(int commentId) {
-		String sql = "DELETE FROM COMMENT WHERE COMMENT_ID  = ?";
+		String sql = "DELETE FROM comment WHERE comment_id  = ?";
 		try (Connection conn = MySQLConnector.getConn();
 				 PreparedStatement stmt = conn.prepareStatement(sql)) {
 			stmt.setInt(1, commentId);

--- a/src/main/java/dao/MessageDAO.java
+++ b/src/main/java/dao/MessageDAO.java
@@ -15,7 +15,7 @@ import connector.MySQLConnector;
 public class MessageDAO {
 
     public void addMessage(MessageBean messageBean) {
-        String sql = "INSERT INTO MESSAGE (RELATION_ID, USER_ID, SEND_MESSAGE) VALUES (?, ?, ?)";
+        String sql = "insert into message (relation_id, user_id, send_message) values (?, ?, ?)";
         try (Connection conn = MySQLConnector.getConn();
              PreparedStatement stmt = conn.prepareStatement(sql)) {
 
@@ -34,18 +34,18 @@ public class MessageDAO {
 
     public List<MessageBean> getMessages(int relationId) {
         List<MessageBean> messages = new ArrayList<>();
-        String sql = "SELECT * FROM MESSAGE WHERE RELATION_ID = ? ORDER BY SEND_TIME DESC";
+        String sql = "select * from message where relation_id = ? order by send_time desc";
         try (Connection conn = MySQLConnector.getConn();
              PreparedStatement stmt = conn.prepareStatement(sql)) {
             stmt.setInt(1, relationId);  // relationIdはint型
             ResultSet rs = stmt.executeQuery();
             while (rs.next()) {
                 MessageBean message = new MessageBean(
-                        rs.getInt("MESSAGE_ID"),
-                        rs.getInt("RELATION_ID"),
-                        rs.getString("USER_ID"),
-                        rs.getTimestamp("SEND_TIME"),
-                        rs.getString("SEND_MESSAGE")
+                        rs.getInt("message_id"),
+                        rs.getInt("relation_id"),
+                        rs.getString("user_id"),
+                        rs.getTimestamp("send_time"),
+                        rs.getString("send_message")
                 );
                 messages.add(message);  // メッセージをリストに追加
             }
@@ -56,7 +56,7 @@ public class MessageDAO {
     }
 
     public void updateMessage(MessageBean messageBean) {
-        String sql = "UPDATE MESSAGE SET SEND_MESSAGE = ? WHERE MESSAGE_ID = ?";
+        String sql = "update message set send_message = ? where message_id = ?";
         try (Connection conn = MySQLConnector.getConn();
              PreparedStatement stmt = conn.prepareStatement(sql)) {
             stmt.setString(1, messageBean.getSendMessage());
@@ -68,7 +68,7 @@ public class MessageDAO {
     }
 
     public void removeMessage(int messageId) {
-        String sql = "DELETE FROM MESSAGE WHERE MESSAGE_ID = ?";
+        String sql = "delete from message where message_id = ?";
         try (Connection conn = MySQLConnector.getConn();
              PreparedStatement stmt = conn.prepareStatement(sql)) {
             stmt.setInt(1, messageId);  // messageIdはint型

--- a/src/main/java/dao/RelationDAO.java
+++ b/src/main/java/dao/RelationDAO.java
@@ -13,7 +13,7 @@ import connector.MySQLConnector;
 public class RelationDAO {
 
     public void addRelation(relationBean relationBean) {
-        String sql = "INSERT INTO Relation (USER1_ID, USER2_ID) VALUES ( ?, ?)";
+        String sql = "INSERT INTO relation (USER1_ID, USER2_ID) VALUES ( ?, ?)";
         try (Connection conn = MySQLConnector.getConn();
              PreparedStatement stmt = conn.prepareStatement(sql)) {
             stmt.setString(1, relationBean.getUser1Id()); 
@@ -26,7 +26,7 @@ public class RelationDAO {
 
     public List<relationBean> getRelation(String userId) {
         List<relationBean> Relations = new ArrayList<>();
-        String sql = "SELECT * FROM Relation WHERE User1_Id = ? OR User2_Id = ?";
+        String sql = "SELECT * FROM relation WHERE User1_Id = ? OR User2_Id = ?";
         try (Connection conn = MySQLConnector.getConn();
              PreparedStatement stmt = conn.prepareStatement(sql)) {
             stmt.setString(1, userId);
@@ -48,7 +48,7 @@ public class RelationDAO {
     }
 
     public void acceptRelation(relationBean relationBean) {
-        String sql = "UPDATE Relation SET status = ? WHERE Relation_ID = ?";
+        String sql = "UPDATE relation SET status = ? WHERE Relation_ID = ?";
         try (Connection conn = MySQLConnector.getConn();
              PreparedStatement stmt = conn.prepareStatement(sql)) {
             stmt.setString(1, relationBean.getStatus());
@@ -60,7 +60,7 @@ public class RelationDAO {
     }
 
     public void cancelRelation(relationBean relationBean) {
-        String sql = "UPDATE Relation SET status = ? WHERE Relation_ID = ?";
+        String sql = "UPDATE relation SET status = ? WHERE Relation_ID = ?";
         try (Connection conn = MySQLConnector.getConn();
              PreparedStatement stmt = conn.prepareStatement(sql)) {
             stmt.setString(1, relationBean.getStatus());

--- a/src/main/java/service/SpotifyAuthService.java
+++ b/src/main/java/service/SpotifyAuthService.java
@@ -32,7 +32,11 @@ import dao.PlayListDAO;
 import dao.UsersDAO;
 
 public class SpotifyAuthService {
-
+	//AWS用
+    //static final String CLIENT_ID = "47d25dfe57a84365a5560a0d4d5b904c";
+    //private static final String CLIENT_SECRET = "85177e25506d47c4b8b2b8de65e68d3b";
+    //static final String REDIRECT_URI = "http://44.193.237.107:8080/SpotMusic/auth";
+    //ローカル用
     static final String CLIENT_ID = "277b350dfbe146e8b5b48171bc6ceaed";
     private static final String CLIENT_SECRET = "5cdda2ff3df040de9b8ba8cbf0122885";
     static final String REDIRECT_URI = "http://localhost:8080/SpotMusic/auth";

--- a/src/main/webapp/WEB-INF/jsp/login.jsp
+++ b/src/main/webapp/WEB-INF/jsp/login.jsp
@@ -7,7 +7,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <link rel="stylesheet" type="text/css" href="<c:url value='/css/login.css' />">
     <link href='https://unpkg.com/boxicons@2.1.4/css/boxicons.min.css' rel='stylesheet'>
-    <title>Spotify</title>
+    <title>SpotMusic - Web Player：すべての人に音楽を</title>
     <style>
         body {
             background-color: black;


### PR DESCRIPTION
DAO修正....AWS→MySQLの大文字小文字全部区別するらしいメンドクサイ...なので独自機能のDAOのクエリ小文字に修正(主にチャットとリレーションだけ)ある程度の動作確認しかしてないので不整合起きるかもしれない。
全部のDAO(特にSpotify側)目を通してないので例外でたらごめん

login.jsp→なぜかtitleがSpotifyでもろパクリ表記だったから修正
connector+SpotifyAuth→AWS環境用をコメントで追記。
AWS環境に合わせてダッシュボードのリダイレクト先等を適合させた俺のクライアントIDとパスをコメントで記載。　
ローカルで動かす人は気にしないで 
SpotifyWebPlayBackSDKの仕組み上、ユーザーが開いてるブラウザで再生できる環境を提供しているわけではなく、ユーザー固有のブラウザで開いている場合に再生先の選択肢として提供(出力先の指定になるので、普通だとスピーカーorヘッドセット、ローカル環境だと+でSpotifySDKが選べるようになる)
らしいのでクラウド上での動作は想定されていないらしいです。
こういうストリーミング系はクラウド、ストレージ上で再生を行っているわけではなく、スマホでもPCでもそのユーザー固有のデバイスを再生先として選択してその選択されたデバイスに再生処理を送っているみたい。.....表現難しい 
従って基本的に動画と発表はローカル環境で。非同期通信の実現がこれで見れたらチャット機能だけクラウド上で...??? 
結論だけでいうと再生プレイヤー(SpotifyWebPlayBackSDK)はクラウド上では動作できません。
SpotifyAPI自体はクラウド上で使えるので、再生命令は出来る(バックグラウンドでSpotify開いていればSpotMusicから再生命令可能、勿論再生機能以外の操作は全部できる) 独自機能はAWS環境は用意したので非同期通信できるかはみんなでテストしましょう....???

マージは全員で再生プレイヤー以外の動作確認後でお願いします。修正漏れてるSQL関係で何かしらの動作で例外出るかもしれない